### PR TITLE
feat: add thinkorswim trading platform

### DIFF
--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -93,6 +93,7 @@
       "openbb-terminal"
       "plex"
       "steam"
+      "thinkorswim"
       "yubico-authenticator"
     ];
 


### PR DESCRIPTION
## Summary
Add TD Ameritrade thinkorswim trading platform to the system configuration via Homebrew cask.

## Changes
- Added `thinkorswim` to the Homebrew casks list in `modules/darwin/default.nix`

## Motivation
Enable financial market analysis and trading capabilities with the thinkorswim desktop application.

## Test Plan
- [x] Tested locally with `darwin-rebuild switch`
- [x] Verified thinkorswim was successfully installed to `/Applications/`
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)