### PR TITLE
feat: switch mullvad to homebrew cask and add WireGuard

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1764325801,
-        "narHash": "sha256-LQ7tsrXs1wuB6KBwUctL3JlUsG/FWI2pCI6NkoO52dk=",
+        "lastModified": 1765990358,
+        "narHash": "sha256-l8x0gU8mnYaGMl+gWrsSHKBJlZWD8KXJfHTkRlFiPI0=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "a696fed6b9b6aa89ef495842cdca3fc2a7cef0de",
+        "rev": "de1b60ca45a578f59f7d84c8d338b346017b2161",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763988335,
-        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
+        "lastModified": 1765911976,
+        "narHash": "sha256-t3T/xm8zstHRLx+pIHxVpQTiySbKqcQbK+r+01XVKc0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
+        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
         "type": "github"
       },
       "original": {
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764636297,
-        "narHash": "sha256-S41K55kw+hWgDfgKmZ9/fMZ3F0BQDMvqFfE120fMHeE=",
+        "lastModified": 1766387499,
+        "narHash": "sha256-AjK3/UKDzeXFeYNLVBaJ3+HLE9he1g5UrlNd4/BM3eA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ff067cfc619fdf6f82d50344e7d19ff2323f0827",
+        "rev": "527ad07e6625302b648ed3b28c34b62a79bd103e",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     "homebrew-cask": {
       "flake": false,
       "locked": {
-        "lastModified": 1764689350,
-        "narHash": "sha256-Tw8KPRImbxXIipx1QGsNDDsQ1vEV/9lu/ZCvXKPLKtw=",
+        "lastModified": 1766430182,
+        "narHash": "sha256-kWaMl5R0HR0NKB8OVwKHMLjbrOvqvK2CDfRbhlNvqyI=",
         "owner": "homebrew",
         "repo": "homebrew-cask",
-        "rev": "347356f312508009c518f364032015c82456cfe5",
+        "rev": "dbaee59516b134e7f0c3fe85a78e2bf5c9215815",
         "type": "github"
       },
       "original": {
@@ -134,11 +134,11 @@
     "homebrew-core": {
       "flake": false,
       "locked": {
-        "lastModified": 1764687440,
-        "narHash": "sha256-NwaMc7kLOSRrUN+g1TYkIG5VvCl19wB+968yplYcZ/U=",
+        "lastModified": 1766430203,
+        "narHash": "sha256-1/pPt8xuIqq158zXUFhZxnw5R0rAUMeFoRrYimQBShM=",
         "owner": "homebrew",
         "repo": "homebrew-core",
-        "rev": "14cbb974bc22d0e68209b383f727e47ce31e5001",
+        "rev": "61e281fcedcbba2552423e5ce6060c5439667e45",
         "type": "github"
       },
       "original": {
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764161084,
-        "narHash": "sha256-HN84sByg9FhJnojkGGDSrcjcbeioFWoNXfuyYfJ1kBE=",
+        "lastModified": 1766038392,
+        "narHash": "sha256-ht/GuKaw5NT3M12xM+mkUtkSBVtzjJ8IHIy6R/ncv9g=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "e95de00a471d07435e0527ff4db092c84998698e",
+        "rev": "5fb45ece6129bd7ad8f7310df0ae9c00bae7c562",
         "type": "github"
       },
       "original": {
@@ -204,11 +204,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1764517877,
-        "narHash": "sha256-pp3uT4hHijIC8JUK5MEqeAWmParJrgBVzHLNfJDZxg4=",
+        "lastModified": 1766309749,
+        "narHash": "sha256-3xY8CZ4rSnQ0NqGhMKAy5vgC+2IVK0NoVEzDoOh4DA4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2d293cbfa5a793b4c50d17c05ef9e385b90edf6c",
+        "rev": "a6531044f6d0bef691ea18d4d4ce44d0daa6e816",
         "type": "github"
       },
       "original": {

--- a/home.nix
+++ b/home.nix
@@ -51,7 +51,6 @@ in
       # Cross-platform apps
       code-cursor
       discord
-      mullvad
       slack
       # spotify # Temporarily disabled due to hash mismatch
       tailscale

--- a/modules/darwin/default.nix
+++ b/modules/darwin/default.nix
@@ -88,7 +88,7 @@
       "microsoft-teams"
       "moonlight"
       # "morgen"
-      # "mullvadvpn"
+      "mullvadvpn"
       "openbb-terminal"
       "plex"
       "steam"
@@ -99,6 +99,7 @@
 
     masApps = {
       "1Password for Safari" = 1569813296;
+      "WireGuard" = 1451685025;
     };
   };
 


### PR DESCRIPTION
## Summary
- Remove mullvad from nix packages
- Enable mullvadvpn homebrew cask
- Add WireGuard from Mac App Store
- Update flake.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)